### PR TITLE
Media is not required

### DIFF
--- a/src/pushNotifications/widget/pushNotifications.js
+++ b/src/pushNotifications/widget/pushNotifications.js
@@ -248,7 +248,7 @@ define([
             case "message":
                 // if this flag is set, this notification happened while we were in the foreground.
                 // you might want to play a sound to get the user"s attention, throw up a dialog, etc.
-                if (e.foreground) {
+                if (e.foreground && typeof Media !== "undefined") {
                     // on Android soundname is outside the payload.
                     // On Amazon FireOS all custom attributes are contained within payload
                      // if the notification contains a soundname, play it.


### PR DESCRIPTION
Check if Media is available, so Media is not a required plugin in Phonegap.